### PR TITLE
fix: Filter result of DNS query to answers of qtype only

### DIFF
--- a/certbot_dns_local/dnsutils.py
+++ b/certbot_dns_local/dnsutils.py
@@ -15,7 +15,8 @@ def dns_get_all(qname, qtype, nameservers=None, authority=False):
     section = response.response.answer if not authority else response.response.authority
     for answer in section:
         for value in answer:
-            result.append(str(value))
+            if value.rdtype.name == qtype:
+                result.append(str(value))
     return result
 
 


### PR DESCRIPTION
Hello there :)
If this project is still alive I'd like to address an issue I've encountered recently.
Query for NS records might receive other record types in the answer (most notably CNAME entries). Treating CNAME as NS obviously brakes resolution of the IP and eventually fails whole authentication.